### PR TITLE
Change to new RAI Institute copyright

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,7 +1,7 @@
 
 MIT License
 
-Copyright (c) 2025 Boston Dynamics AI Institute LLC
+Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/examples/embodied_environments/pusht_embodied/pusht_embodied.py
+++ b/examples/embodied_environments/pusht_embodied/pusht_embodied.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import json
 from pathlib import Path

--- a/examples/example_embodied_pusht_offline.py
+++ b/examples/example_embodied_pusht_offline.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import trio
 from pathlib import Path

--- a/examples/example_pusht.py
+++ b/examples/example_pusht.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from dataclasses import dataclass, field
 

--- a/examples/example_pusht_datacollector.py
+++ b/examples/example_pusht_datacollector.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from dataclasses import dataclass, field
 from pathlib import Path

--- a/examples/example_pusht_datainspector.py
+++ b/examples/example_pusht_datainspector.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from dataclasses import dataclass
 from pathlib import Path

--- a/examples/helpers/canvas_2d.py
+++ b/examples/helpers/canvas_2d.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import marsoom
 import numpy as np

--- a/examples/sim_environments/pusht.py
+++ b/examples/sim_environments/pusht.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from dataclasses import dataclass
 from pathlib import Path

--- a/src/embodied_gaussians/dataset/dataset_manager.py
+++ b/src/embodied_gaussians/dataset/dataset_manager.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import json
 import typing

--- a/src/embodied_gaussians/dataset/dataset_visualizer.py
+++ b/src/embodied_gaussians/dataset/dataset_visualizer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from dataclasses import dataclass
 from pathlib import Path

--- a/src/embodied_gaussians/embodied_simulator/appearance_optimizer.py
+++ b/src/embodied_gaussians/embodied_simulator/appearance_optimizer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import warp as wp
 import torch

--- a/src/embodied_gaussians/embodied_simulator/builder.py
+++ b/src/embodied_gaussians/embodied_simulator/builder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import numpy as np
 

--- a/src/embodied_gaussians/embodied_simulator/frames.py
+++ b/src/embodied_gaussians/embodied_simulator/frames.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from dataclasses import dataclass
 import numpy as np

--- a/src/embodied_gaussians/embodied_simulator/gaussians.py
+++ b/src/embodied_gaussians/embodied_simulator/gaussians.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from dataclasses import dataclass
 import torch

--- a/src/embodied_gaussians/embodied_simulator/loader.py
+++ b/src/embodied_gaussians/embodied_simulator/loader.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from pathlib import Path
 

--- a/src/embodied_gaussians/embodied_simulator/offline_camera.py
+++ b/src/embodied_gaussians/embodied_simulator/offline_camera.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from pathlib import Path
 import numpy as np

--- a/src/embodied_gaussians/embodied_simulator/offline_cameras.py
+++ b/src/embodied_gaussians/embodied_simulator/offline_cameras.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import json
 from pathlib import Path

--- a/src/embodied_gaussians/embodied_simulator/saver.py
+++ b/src/embodied_gaussians/embodied_simulator/saver.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import logging
 from typing_extensions import override

--- a/src/embodied_gaussians/embodied_simulator/simulator.py
+++ b/src/embodied_gaussians/embodied_simulator/simulator.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from typing import Literal
 import pysegreduce

--- a/src/embodied_gaussians/embodied_simulator/visual_forces.py
+++ b/src/embodied_gaussians/embodied_simulator/visual_forces.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from dataclasses import dataclass
 import torch

--- a/src/embodied_gaussians/embodied_simulator/warp.py
+++ b/src/embodied_gaussians/embodied_simulator/warp.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import warp as wp
 

--- a/src/embodied_gaussians/embodied_visualizer/embodied_viewer.py
+++ b/src/embodied_gaussians/embodied_visualizer/embodied_viewer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from dataclasses import dataclass
 from pathlib import Path

--- a/src/embodied_gaussians/embodied_visualizer/visualizer.py
+++ b/src/embodied_gaussians/embodied_visualizer/visualizer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import marsoom.overlay
 

--- a/src/embodied_gaussians/environments/embodied_environment.py
+++ b/src/embodied_gaussians/environments/embodied_environment.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from dataclasses import dataclass
 from pathlib import Path

--- a/src/embodied_gaussians/environments/environment.py
+++ b/src/embodied_gaussians/environments/environment.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import abc
 import typing

--- a/src/embodied_gaussians/environments/virtual_cameras.py
+++ b/src/embodied_gaussians/environments/virtual_cameras.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from dataclasses import dataclass
 

--- a/src/embodied_gaussians/physics_simulator/builder.py
+++ b/src/embodied_gaussians/physics_simulator/builder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import numpy as np
 import warp as wp

--- a/src/embodied_gaussians/physics_simulator/integrator.py
+++ b/src/embodied_gaussians/physics_simulator/integrator.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from typing_extensions import override
 import warp as wp

--- a/src/embodied_gaussians/physics_simulator/loader.py
+++ b/src/embodied_gaussians/physics_simulator/loader.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import warnings
 from pathlib import Path

--- a/src/embodied_gaussians/physics_simulator/saver.py
+++ b/src/embodied_gaussians/physics_simulator/saver.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import logging
 import pickle

--- a/src/embodied_gaussians/physics_simulator/simulator.py
+++ b/src/embodied_gaussians/physics_simulator/simulator.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from dataclasses import dataclass
 

--- a/src/embodied_gaussians/physics_visualizer/simulation_gui.py
+++ b/src/embodied_gaussians/physics_visualizer/simulation_gui.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import marsoom
 import marsoom.overlay

--- a/src/embodied_gaussians/physics_visualizer/simulation_viewer.py
+++ b/src/embodied_gaussians/physics_visualizer/simulation_viewer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import marsoom
 import marsoom.cuda

--- a/src/embodied_gaussians/scene_builders/domain.py
+++ b/src/embodied_gaussians/scene_builders/domain.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from pathlib import Path
 from typing import Literal

--- a/src/embodied_gaussians/scene_builders/pointcloud_body_builder.py
+++ b/src/embodied_gaussians/scene_builders/pointcloud_body_builder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from dataclasses import dataclass, field
 from collections import namedtuple

--- a/src/embodied_gaussians/scene_builders/simple_body_builder.py
+++ b/src/embodied_gaussians/scene_builders/simple_body_builder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from dataclasses import dataclass, field
 from collections import namedtuple

--- a/src/embodied_gaussians/scene_builders/simple_visualizer.py
+++ b/src/embodied_gaussians/scene_builders/simple_visualizer.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import open3d as o3d
 import numpy as np

--- a/src/embodied_gaussians/scene_builders/warp_utils.py
+++ b/src/embodied_gaussians/scene_builders/warp_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import torch
 import warp as wp

--- a/src/embodied_gaussians/utils/physics_utils.py
+++ b/src/embodied_gaussians/utils/physics_utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import dataclasses
 import pickle

--- a/src/embodied_gaussians/utils/utils.py
+++ b/src/embodied_gaussians/utils/utils.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import typing
 

--- a/src/ground_finder/ground_finder.py
+++ b/src/ground_finder/ground_finder.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 from dataclasses import dataclass
 import typing

--- a/src/quick_segmentor/quick_segmentor.py
+++ b/src/quick_segmentor/quick_segmentor.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import numpy as np
 from isegm_gui import run_interactive_segmentor, load_model

--- a/src/sam_segmentor/sam_segementor.py
+++ b/src/sam_segmentor/sam_segementor.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2025 Boston Dynamics AI Institute LLC. All rights reserved.
+# Copyright (c) 2025 Robotics and AI Institute LLC dba RAI Institute. All rights reserved.
 
 import numpy as np
 import cv2


### PR DESCRIPTION
Automated update to fix copyright headers with new organization name.

"Boston Dynamics AI Institute LLC" has been changed to "Robotics and AI Institute LLC" or "RAI Institute" for short.

Note that the date-stamps in the copyright headers have been preserved. Only files with existing copyrights have been modified.

This PR was created automatically.